### PR TITLE
Use spaces rather than tabs for indentation

### DIFF
--- a/src/main/java/libcorrect/convolutional/BitReader.java
+++ b/src/main/java/libcorrect/convolutional/BitReader.java
@@ -8,56 +8,56 @@ package libcorrect.convolutional;
 
 public class BitReader {
 
-	private static final byte[] reverseTable_U = createReverseTable();
+    private static final byte[] reverseTable_U = createReverseTable();
 
-	private static byte[] createReverseTable() {
+    private static byte[] createReverseTable() {
     byte[] rT_U = new byte[256];
-		for(int i = 0; i < 256; i++) {
-			rT_U[i] =
+        for(int i = 0; i < 256; i++) {
+            rT_U[i] =
         (byte)((i & 0x80) >> 7 | (i & 0x40) >> 5 | (i & 0x20) >> 3 | 
                (i & 0x10) >> 1 | (i & 0x08) << 1 | (i & 0x04) << 3 | 
                (i & 0x02) << 5 | (i & 0x01) << 7);
-		}
-		return rT_U;
-	}
+        }
+        return rT_U;
+    }
 
-	byte currentByte_U;;
-	long byteIndex_U;
-  	long len_U;
-  	long currentByteLen_U;
- 	byte[] bytes_U;
+    byte currentByte_U;;
+    long byteIndex_U;
+    long len_U;
+    long currentByteLen_U;
+    byte[] bytes_U;
 
-	public BitReader(byte[] bytes_U, long len_U) {
-		if(bytes_U != null) {
-			reconfigure(bytes_U, len_U);
-		}
-	}
+    public BitReader(byte[] bytes_U, long len_U) {
+        if(bytes_U != null) {
+            reconfigure(bytes_U, len_U);
+        }
+    }
 
-	public void reconfigure(byte[] bytes_U, long len_U) {
-		this.bytes_U = bytes_U;
-		this.len_U = len_U;
-		this.currentByteLen_U = 8;
-		this.currentByte_U=bytes_U[0];
-		this.byteIndex_U=0;
-	}
+    public void reconfigure(byte[] bytes_U, long len_U) {
+        this.bytes_U = bytes_U;
+        this.len_U = len_U;
+        this.currentByteLen_U = 8;
+        this.currentByte_U=bytes_U[0];
+        this.byteIndex_U=0;
+    }
 
-	public byte read(int n_U) {
-		int read_U = 0;
-		int nCopy_U = n_U;
+    public byte read(int n_U) {
+        int read_U = 0;
+        int nCopy_U = n_U;
 
-		if(Long.compareUnsigned(this.currentByteLen_U, Integer.toUnsignedLong(n_U)) < 0) {
-			read_U = Byte.toUnsignedInt(this.currentByte_U) & (1 << this.currentByteLen_U) - 1;
-			this.byteIndex_U++;
-			this.currentByte_U = this.bytes_U[(int)this.byteIndex_U];
-			n_U = (int)(Integer.toUnsignedLong(n_U) - this.currentByteLen_U);
-			this.currentByteLen_U=8;
-			read_U <<= n_U;
-		}
+        if(Long.compareUnsigned(this.currentByteLen_U, Integer.toUnsignedLong(n_U)) < 0) {
+            read_U = Byte.toUnsignedInt(this.currentByte_U) & (1 << this.currentByteLen_U) - 1;
+            this.byteIndex_U++;
+            this.currentByte_U = this.bytes_U[(int)this.byteIndex_U];
+            n_U = (int)(Integer.toUnsignedLong(n_U) - this.currentByteLen_U);
+            this.currentByteLen_U=8;
+            read_U <<= n_U;
+        }
 
-		byte copyMask_U = (byte)((1 << n_U) - 1);
-		copyMask_U = (byte)(Byte.toUnsignedInt(copyMask_U) << this.currentByteLen_U - Integer.toUnsignedLong(n_U));
-		read_U |= (Byte.toUnsignedInt(this.currentByte_U) & Byte.toUnsignedInt(copyMask_U)) >> this.currentByteLen_U - Integer.toUnsignedLong(n_U);
-		this.currentByteLen_U = this.currentByteLen_U - Integer.toUnsignedLong(n_U);
-		return (byte)(Byte.toUnsignedInt(reverseTable_U[read_U]) >> 8 - nCopy_U);
-	}
+        byte copyMask_U = (byte)((1 << n_U) - 1);
+        copyMask_U = (byte)(Byte.toUnsignedInt(copyMask_U) << this.currentByteLen_U - Integer.toUnsignedLong(n_U));
+        read_U |= (Byte.toUnsignedInt(this.currentByte_U) & Byte.toUnsignedInt(copyMask_U)) >> this.currentByteLen_U - Integer.toUnsignedLong(n_U);
+        this.currentByteLen_U = this.currentByteLen_U - Integer.toUnsignedLong(n_U);
+        return (byte)(Byte.toUnsignedInt(reverseTable_U[read_U]) >> 8 - nCopy_U);
+    }
 }

--- a/src/test/java/libcorrect/convolutional/ConvTestbench.java
+++ b/src/test/java/libcorrect/convolutional/ConvTestbench.java
@@ -62,7 +62,7 @@ public class ConvTestbench {
             ErrorSim.buildWhiteNoise(noise, enclen, ebN0, bpskBitEnergy);
             numErrors += testConvNoise(msg_U, blockLen_U, bpskVoltage);
         }
-		return numErrors;
+        return numErrors;
     }
 
     public int testConvNoise(byte[] msg, long nBytes, double bpskVoltage) {


### PR DESCRIPTION
Most of libcorrect4j uses spaces for indentation (about 2000 lines of code).
A small part of libcorrect4j uses tabs for indentation (about 40 lines of code).
This pull request makes the codebase consistent.
