### PR TITLE
Consistently use unsigned operations on unsigned values

### DIFF
--- a/src/main/java/libcorrect/convolutional/BitReader.java
+++ b/src/main/java/libcorrect/convolutional/BitReader.java
@@ -58,6 +58,6 @@ public class BitReader {
 		copyMask_U = (byte)(Byte.toUnsignedInt(copyMask_U) << this.currentByteLen_U - Integer.toUnsignedLong(n_U));
 		read_U |= (Byte.toUnsignedInt(this.currentByte_U) & Byte.toUnsignedInt(copyMask_U)) >> this.currentByteLen_U - Integer.toUnsignedLong(n_U);
 		this.currentByteLen_U = this.currentByteLen_U - Integer.toUnsignedLong(n_U);
-		return (byte)(Byte.toUnsignedInt(reverseTable_U[read_U]) >> 8 - nCopy_U);
+		return (byte)(Byte.toUnsignedInt(reverseTable_U[read_U]) >>> 8 - nCopy_U);
 	}
 }

--- a/src/main/java/libcorrect/convolutional/BitReader.java
+++ b/src/main/java/libcorrect/convolutional/BitReader.java
@@ -17,48 +17,47 @@ public class BitReader {
         (byte)((i & 0x80) >> 7 | (i & 0x40) >> 5 | (i & 0x20) >> 3 | 
                (i & 0x10) >> 1 | (i & 0x08) << 1 | (i & 0x04) << 3 | 
                (i & 0x02) << 5 | (i & 0x01) << 7);
-    }
-    return rT_U;
-  }
-
-  byte currentByte_U;;
-  long byteIndex_U;
-  long len_U;
-  long currentByteLen_U;
-  byte[] bytes_U;
-
-  public BitReader(byte[] bytes_U, long len_U) {
-    if(bytes_U != null) {
-      reconfigure(bytes_U, len_U);
-    }
-  }
-
-  public void reconfigure(byte[] bytes_U, long len_U) {
-    this.bytes_U = bytes_U;
-    this.len_U = len_U;
-    this.currentByteLen_U = 8;
-    this.currentByte_U=bytes_U[0];
-    this.byteIndex_U=0;
-  }
-
-  public byte read(int n_U) {
-    int read_U = 0;
-    int nCopy_U = n_U;
-
-    if(Long.compareUnsigned(this.currentByteLen_U, Integer.toUnsignedLong(n_U)) < 0) {
-      read_U = Byte.toUnsignedInt(this.currentByte_U) & (1 << this.currentByteLen_U) - 1;
-      this.byteIndex_U++;
-      this.currentByte_U = this.bytes_U[(int)this.byteIndex_U];
-      n_U = (int)(Integer.toUnsignedLong(n_U) - this.currentByteLen_U);
-      this.currentByteLen_U=8;
-      read_U <<= n_U;
+        }
+        return rT_U;
     }
 
-    byte copyMask_U = (byte)((1 << n_U) - 1);
-    copyMask_U = (byte)(Byte.toUnsignedInt(copyMask_U) << this.currentByteLen_U - Integer.toUnsignedLong(n_U));
-    read_U |= (Byte.toUnsignedInt(this.currentByte_U) & Byte.toUnsignedInt(copyMask_U)) >> this.currentByteLen_U - Integer.toUnsignedLong(n_U);
-    this.currentByteLen_U = this.currentByteLen_U - Integer.toUnsignedLong(n_U);
-    return (byte)(Byte.toUnsignedInt(reverseTable_U[read_U]) >>> 8 - nCopy_U);
-  }
+    byte currentByte_U;;
+    long byteIndex_U;
+    long len_U;
+    long currentByteLen_U;
+    byte[] bytes_U;
 
+    public BitReader(byte[] bytes_U, long len_U) {
+        if(bytes_U != null) {
+            reconfigure(bytes_U, len_U);
+        }
+    }
+
+    public void reconfigure(byte[] bytes_U, long len_U) {
+        this.bytes_U = bytes_U;
+        this.len_U = len_U;
+        this.currentByteLen_U = 8;
+        this.currentByte_U=bytes_U[0];
+        this.byteIndex_U=0;
+    }
+
+    public byte read(int n_U) {
+        int read_U = 0;
+        int nCopy_U = n_U;
+
+        if(Long.compareUnsigned(this.currentByteLen_U, Integer.toUnsignedLong(n_U)) < 0) {
+            read_U = Byte.toUnsignedInt(this.currentByte_U) & (1 << this.currentByteLen_U) - 1;
+            this.byteIndex_U++;
+            this.currentByte_U = this.bytes_U[(int)this.byteIndex_U];
+            n_U = (int)(Integer.toUnsignedLong(n_U) - this.currentByteLen_U);
+            this.currentByteLen_U=8;
+            read_U <<= n_U;
+        }
+
+        byte copyMask_U = (byte)((1 << n_U) - 1);
+        copyMask_U = (byte)(Byte.toUnsignedInt(copyMask_U) << this.currentByteLen_U - Integer.toUnsignedLong(n_U));
+        read_U |= (Byte.toUnsignedInt(this.currentByte_U) & Byte.toUnsignedInt(copyMask_U)) >> this.currentByteLen_U - Integer.toUnsignedLong(n_U);
+        this.currentByteLen_U = this.currentByteLen_U - Integer.toUnsignedLong(n_U);
+        return (byte)(Byte.toUnsignedInt(reverseTable_U[read_U]) >>> 8 - nCopy_U);
+    }
 }

--- a/src/main/java/libcorrect/convolutional/Convolutional.java
+++ b/src/main/java/libcorrect/convolutional/Convolutional.java
@@ -217,7 +217,7 @@ public class Convolutional {
         if (Integer.compareUnsigned(iter, 2_220) < 0) {
             return;
         }
-        System.out.println("iteration: " + Integer.toUnsignedString(iter);
+        System.out.println("iteration: " + Integer.toUnsignedString(iter));
         System.out.println("errors:");
         for (int i = 0; Integer.compareUnsigned(i, Integer.divideUnsigned(numstates_U, 2)) < 0; i++) {
             System.out.printf("%2d: %d\n", i, Short.toUnsignedInt(errorBuffer.getWriteError(i)));

--- a/src/main/java/libcorrect/convolutional/Convolutional.java
+++ b/src/main/java/libcorrect/convolutional/Convolutional.java
@@ -217,7 +217,7 @@ public class Convolutional {
         if (Integer.compareUnsigned(iter, 2_220) < 0) {
             return;
         }
-        System.out.println("iteration: " + iter);
+        System.out.println("iteration: " + Integer.toUnsignedString(iter);
         System.out.println("errors:");
         for (int i = 0; Integer.compareUnsigned(i, Integer.divideUnsigned(numstates_U, 2)) < 0; i++) {
             System.out.printf("%2d: %d\n", i, Short.toUnsignedInt(errorBuffer.getWriteError(i)));

--- a/src/main/java/libcorrect/convolutional/Convolutional.java
+++ b/src/main/java/libcorrect/convolutional/Convolutional.java
@@ -266,7 +266,7 @@ public class Convolutional {
 
         // we limit history to go back as far as 5 * the order of our polynomial
         historyBuffer = new HistoryBuffer(minTraceback_U, tracebackLength_U, renormalizeInterval_U,
-                numstates_U / 2, 1 << (order_U - 1));
+                Integer.divideUnsigned(numstates_U, 2), 1 << (order_U - 1));
         errorBuffer = new ErrorBuffer(numstates_U);
     }
 

--- a/src/main/java/libcorrect/convolutional/HistoryBuffer.java
+++ b/src/main/java/libcorrect/convolutional/HistoryBuffer.java
@@ -72,7 +72,7 @@ public class HistoryBuffer {
         int leasterror_U = Integer.MAX_VALUE;
         // search for a state with the least error
         for(int state_U = 0; Integer.compareUnsigned(state_U, numStates_U) < 0; state_U += searchEvery_U) {
-            if(Short.toUnsignedInt(distances_U[state_U]) < leasterror_U) {
+            if(Integer.compareUnsigned(Short.toUnsignedInt(distances_U[state_U]), leasterror_U) < 0) {
                 leasterror_U = distances_U[state_U];
                 bestpath_U = state_U;
             }

--- a/src/main/java/libcorrect/convolutional/Metric.java
+++ b/src/main/java/libcorrect/convolutional/Metric.java
@@ -39,7 +39,7 @@ public class Metric {
             int d = Byte.toUnsignedInt(softY_U[i+shift]) - softX_U;
             dist_U = (short)(Short.toUnsignedInt(dist_U) + d * d);
         }
-        return (short)(Short.toUnsignedInt(dist_U) >> 3);
+        return (short)(Short.toUnsignedInt(dist_U) >>> 3);
     }
 
 }


### PR DESCRIPTION
In a handful of spots, the code uses signed operations on unsigned values. This may result in nonsense values. This pull request corrects the ones I noticed. 