### PR TITLE
Always treat unsigned bytes as if they are unsigned bytes

### DIFF
--- a/src/main/java/libcorrect/reed_solomon/ReedSolomon.java
+++ b/src/main/java/libcorrect/reed_solomon/ReedSolomon.java
@@ -610,7 +610,7 @@ public class ReedSolomon {
 
             byte loc_U = field.fieldDiv((byte) 1, errorRoots[i]);
             for (int j = 0; j < 256; j++) {
-                if (field.fieldPow((byte) j, gRootGap) == loc_U) {
+                if (field.fieldPow((byte) j, Byte.toUnsignedInt(gRootGap)) == loc_U) {
                     errorLocations[i] = field.log(j);
                     break;
                 }
@@ -626,7 +626,7 @@ public class ReedSolomon {
      */
     private void findErrorRootsFromLocations(byte generatorRootGap, int numErrors) {
         for (int i = 0; Integer.compareUnsigned(i, numErrors) < 0; i++) {
-            byte loc_U = field.fieldPow(field.exp(Byte.toUnsignedInt(errorLocations[i])), generatorRootGap);
+            byte loc_U = field.fieldPow(field.exp(Byte.toUnsignedInt(errorLocations[i])), Byte.toUnsignedInt(generatorRootGap));
             // field_element_t loc = field.exp[error_locations[i]];
             errorRoots[i] = field.fieldDiv((byte) 1, loc_U);
         }
@@ -798,7 +798,7 @@ public class ReedSolomon {
 
         System.out.print("error roots: ");
         for (int i = 0; Integer.compareUnsigned(i, errorLocator.getOrder()) < 0; i++) {
-            System.out.print(eval(field, errorLocator, errorRoots[i]) + "@" + Byte.toUnsignedInt(errorRoots[i]));
+            System.out.print(Byte.toUnsignedInt(eval(field, errorLocator, errorRoots[i])) + "@" + Byte.toUnsignedInt(errorRoots[i]));
             if (Integer.compareUnsigned(i, errorLocator.getOrder() - 1) < 0) {
                 System.out.print(", ");
             }


### PR DESCRIPTION
Many of the byte values, including the 'generator root gap' are meant to be unsigned 8-bit quantities. There are three places in the codebase where this isn't properly respected.

The eval() method in Polynomial.java returns such a byte quantity, but on line 801 of the ReedSolomon.java file (in the debugPrint method) it is converted to a string in a signed manner.
Additionally, in two places the 'generator root gap' is implicitly converted to an integer and passed as argument pow to the fieldPow method in Field.java. This conversion works differently in the original C code than it does in the Java code - the byte will be zero-padded in C but sign-extended in Java.
In the original libcorrect, the generator root gap is defined [here](https://github.com/quiet/libcorrect/blob/f5a28c74fba7a99736fe49d3a5243eca29517ae9/src/reed-solomon/decode.c#L198) and [here](https://github.com/quiet/libcorrect/blob/f5a28c74fba7a99736fe49d3a5243eca29517ae9/src/reed-solomon/decode.c#L226). It is defined as a [uint8_t](https://github.com/quiet/libcorrect/blob/f5a28c74fba7a99736fe49d3a5243eca29517ae9/include/correct/reed-solomon.h#L17). It is passed to the [field_pow](https://github.com/quiet/libcorrect/blob/f5a28c74fba7a99736fe49d3a5243eca29517ae9/include/correct/reed-solomon/field.h#L155) function. In the C code, the conversion from unsigned byte to signed int doesn't sign-extend the byte. However, the Java port as-written does sign-extend the byte to create an int.
This pull request inserts calls to Byte.toUnsignedInt() to bring the behavior into line with the C code.