### PR TITLE
Replace unneeded compareUnsigned calls

### DIFF
--- a/src/main/java/libcorrect/reed_solomon/Field.java
+++ b/src/main/java/libcorrect/reed_solomon/Field.java
@@ -80,7 +80,7 @@ public class Field {
         // an odd number of XORs puts you back at your value
 
         // so, just throw away all the even n
-        return (byte) (Integer.remainderUnsigned(n_U, 2) != 0 ? Byte.toUnsignedInt(elem_U) : 0);
+        return (byte) (n_U % 2 != 0 ? Byte.toUnsignedInt(elem_U) : 0);
     }
 
     public byte fieldMul(byte l, byte r) {

--- a/src/main/java/libcorrect/reed_solomon/Polynomial.java
+++ b/src/main/java/libcorrect/reed_solomon/Polynomial.java
@@ -61,10 +61,10 @@ public class Polynomial implements Cloneable {
 
         // loop through, using previous run's result as the new right hand side
         // this allows us to multiply one group at a time
-        for (int i = 1; Integer.compareUnsigned(i, nRoots) < 0; i++) {
+        for (int i = 1; i < nRoots; i++) {
             l.coeff[0] =  roots[i];
             int nextRCoeff = rCoeffRes;
-            rCoeffRes = Integer.remainderUnsigned(rCoeffRes + 1, 2);
+            rCoeffRes = (rCoeffRes + 1) % 2;
             r[rCoeffRes].order = i + 1;
             mul(field, l, r[nextRCoeff], r[rCoeffRes]);
         }
@@ -118,12 +118,12 @@ public class Polynomial implements Cloneable {
 
     public static void mul(Field field, Polynomial l, Polynomial r, Polynomial res) {
          Arrays.fill(res.coeff, (byte) 0);
-        for (int i = 0; Integer.compareUnsigned(i, l.order) <= 0; i++) {
-            if (Integer.compareUnsigned(i, res.order) > 0) {
+        for (int i = 0; i <= l.order; i++) {
+            if (i > res.order) {
                 continue;
             }
-            int jLimit_U = Integer.compareUnsigned(r.order, res.order - i) > 0 ? res.order - i : r.order;
-            for (int j = 0; Integer.compareUnsigned(j, jLimit_U) <= 0; j++) {
+            int jLimit_U = r.order > res.order - i ? res.order - i : r.order;
+            for (int j = 0; j <= jLimit_U; j++) {
                 // e.g. alpha^5*x * alpha^37*x^2 --> alpha^42*x^3
                 res.coeff[i + j] = field.fieldAdd(res.coeff[i + j],
                         field.fieldMul(l.coeff[i], r.coeff[j]));
@@ -141,7 +141,7 @@ public class Polynomial implements Cloneable {
      */
     public static void mod(Field field, Polynomial dividend, Polynomial divisor, Polynomial mod) {
 
-        if (Integer.compareUnsigned(mod.order, dividend.order) < 0) {
+        if (mod.order < dividend.order) {
             // mod.order must be >= dividend.order (scratch space needed)
             // this is an error -- catch it in debug?
             return;
@@ -154,12 +154,12 @@ public class Polynomial implements Cloneable {
         byte divisorLeading = field.log(Byte.toUnsignedInt(divisor.coeff[divisor.order]));
 
         // long division steps along one order at a time, starting at the highest order
-        for (int i = dividend.order; Integer.compareUnsigned(i, 0) > 0; i--) {
+        for (int i = dividend.order; i > 0; i--) {
             // look at the leading coefficient of dividend and divisor
             // if leading coefficient of dividend / leading coefficient of divisor is q
             //   then the next row of subtraction will be q * divisor
             // if order of q < 0 then what we have is the remainder and we are done
-            if (Integer.compareUnsigned(i, divisor.order) < 0) {
+            if (i < divisor.order) {
                 break;
             }
             if (Byte.toUnsignedInt(mod.coeff[i]) == 0) {
@@ -194,7 +194,7 @@ public class Polynomial implements Cloneable {
 
         // assumes der.order = poly.order - 1
         Arrays.fill(der.coeff, (byte) 0);
-        for (int i = 0; Integer.compareUnsigned(i, der.order) <= 0; i++) {
+        for (int i = 0;i <= der.order; i++) {
             // we're filling in the ith power of der, so we look ahead one power in poly
             // f(x) = a(i + 1)*x^(i + 1) -> f'(x) = (i + 1)*a(i + 1)*x^i
             // where (i + 1)*a(i + 1) is the sum of a(i + 1) (i + 1) times, not the product
@@ -221,7 +221,7 @@ public class Polynomial implements Cloneable {
         byte valExponentiated = field.log(1);
         byte valLog = field.log(Byte.toUnsignedInt(val));
 
-        for (int i = 0; Integer.compareUnsigned(i, poly.order) <= 0; i++) {
+        for (int i = 0; i <= poly.order; i++) {
             if (Byte.toUnsignedInt(poly.coeff[i]) != 0) {
                 // multiply-accumulate by the next coeff times the next power of val
                 res = field.fieldAdd(res, field.fieldMulLogElement(field.log(Byte.toUnsignedInt(poly.coeff[i])),
@@ -277,7 +277,7 @@ public class Polynomial implements Cloneable {
 
         byte res = 0;
 
-        for (int i = 0; Integer.compareUnsigned(i, order) <= 0; i++) {
+        for (int i = 0; i <= order; i++) {
             // using 0 as a sentinel value in log -- log(0) is really -inf
             if (Byte.toUnsignedInt(coeff[i]) != 0) {
                 // multiply-accumulate by the next coeff times the next power of val
@@ -297,7 +297,7 @@ public class Polynomial implements Cloneable {
     public static void buildExpLut(Field field, byte val, int order, byte[] valExp) {
         byte valExponentiated = field.log(1);
         byte valLog = field.log(Byte.toUnsignedInt(val));
-        for (int i = 0; Integer.compareUnsigned(i, order) <= 0; i++) {
+        for (int i = 0; i <= order; i++) {
             if (Byte.toUnsignedInt(val) == 0) {
                 valExp[i] = (byte) 0;
             } else {
@@ -336,10 +336,10 @@ public class Polynomial implements Cloneable {
 
         // loop through, using previous run's result as the new right hand side
         // this allows us to multiply one group at a time
-        for (int i = 1; Integer.compareUnsigned(i, nRoots) < 0; i++) {
+        for (int i = 1; i < nRoots; i++) {
             l.coeff[0] = roots[i];
             int nextRCoeff = rCoeffRes;
-            rCoeffRes = Integer.remainderUnsigned(rCoeffRes + 1, 2);
+            rCoeffRes = (rCoeffRes + 1) % 2;
             r[rCoeffRes].order = i + 1;
             mul(field, l, r[nextRCoeff], r[rCoeffRes]);
         }

--- a/src/main/java/libcorrect/reed_solomon/Polynomial.java
+++ b/src/main/java/libcorrect/reed_solomon/Polynomial.java
@@ -170,7 +170,7 @@ public class Polynomial implements Cloneable {
 
             // now that we've chosen q, multiply the divisor by q and subtract from
             //   our remainder. subtracting in GF(2^8) is XOR, just like addition
-            for (int j = 0; Integer.compareUnsigned(j, divisor.order) <= 0; j++) {
+            for (int j = 0; j <= divisor.order; j++) {
                 if (Byte.toUnsignedInt(divisor.coeff[j]) == 0) {
                     continue;
                 }
@@ -249,7 +249,7 @@ public class Polynomial implements Cloneable {
 
         byte res = 0;
 
-        for (int i = 0; Integer.compareUnsigned(i, order) <= 0; i++) {
+        for (int i = 0; i <= order; i++) {
             if (Byte.toUnsignedInt(coeff[i]) != 0) {
                 // multiply-accumulate by the next coeff times the next power of val
                 res = field.fieldAdd(res, field.fieldMulLogElement(field.log(Byte.toUnsignedInt(coeff[i])), valExp[i]));

--- a/src/main/java/libcorrect/reed_solomon/Polynomial.java
+++ b/src/main/java/libcorrect/reed_solomon/Polynomial.java
@@ -194,7 +194,7 @@ public class Polynomial implements Cloneable {
 
         // assumes der.order = poly.order - 1
         Arrays.fill(der.coeff, (byte) 0);
-        for (int i = 0;i <= der.order; i++) {
+        for (int i = 0; i <= der.order; i++) {
             // we're filling in the ith power of der, so we look ahead one power in poly
             // f(x) = a(i + 1)*x^(i + 1) -> f'(x) = (i + 1)*a(i + 1)*x^i
             // where (i + 1)*a(i + 1) is the sum of a(i + 1) (i + 1) times, not the product

--- a/src/main/java/libcorrect/reed_solomon/ReedSolomon.java
+++ b/src/main/java/libcorrect/reed_solomon/ReedSolomon.java
@@ -467,7 +467,7 @@ public class ReedSolomon {
                 // locator = locator - last_locator
                 // we will also update last_locator to be locator before this loop takes place
                 byte temp;
-                for (int j = 0; j <= (lastErrorLocator.getOrder() + delayLength); j++) {
+                for (int j = 0; j <= lastErrorLocator.getOrder() + delayLength; j++) {
                     temp = errorLocator.getCoeff(j);
                     errorLocator.setCoeff(j, field.fieldAdd(errorLocator.getCoeff(j), lastErrorLocator.getCoeff(j)));
                     lastErrorLocator.setCoeff(j, temp);

--- a/src/main/java/libcorrect/reed_solomon/ReedSolomon.java
+++ b/src/main/java/libcorrect/reed_solomon/ReedSolomon.java
@@ -124,18 +124,18 @@ public class ReedSolomon {
             // message goes from high order to low order but libcorrect polynomials go low to high
             // so we reverse on the way in and on the way out
             // we'd have to do a copy anyway so this reversal should be free
-            encodedPolynomial.setCoeff((int) (Integer.toUnsignedLong(encodedPolynomial.getOrder()) - (Integer.toUnsignedLong(i) + padLength)), msg[i]);
+            encodedPolynomial.setCoeff((int) (encodedPolynomial.getOrder() - (i + padLength)), msg[i]);
         }
 
         Polynomial.mod(field, encodedPolynomial, generator, encodedRemainder);
 
         // now return byte order to highest order to lowest order
         for (int i = 0; i < msgLength; i++) {
-            encoded[i] = encodedPolynomial.getCoeff((int) (Integer.toUnsignedLong(encodedPolynomial.getOrder()) - (Integer.toUnsignedLong(i) + padLength)));
+            encoded[i] = encodedPolynomial.getCoeff((int) (encodedPolynomial.getOrder() - (i + padLength)));
         }
 
         for (int i = 0; i < minDistance; i++) {
-            encoded[(int) (msgLength + Integer.toUnsignedLong(i))] = encodedRemainder.getCoeff((int) (minDistance - Integer.toUnsignedLong(i + 1)));
+            encoded[(int) (msgLength + Integer.toUnsignedLong(i))] = encodedRemainder.getCoeff((int) (minDistance - (i + 1)));
         }
 
         return encoded;

--- a/src/main/java/libcorrect/reed_solomon/ReedSolomon.java
+++ b/src/main/java/libcorrect/reed_solomon/ReedSolomon.java
@@ -434,7 +434,7 @@ public class ReedSolomon {
         byte lastDiscrepancy = 1;
         int delayLength = 1;
 
-        for (int i = errorLocator.getOrder(); i < (minDistance - numErasures); i++) {
+        for (int i = errorLocator.getOrder(); i < minDistance - numErasures; i++) {
             discrepancy = syndromes[i];
             for (int j = 1; j <= numerrors; j++) {
                 discrepancy = (byte) field.fieldAdd(discrepancy, field.fieldMul(errorLocator.getCoeff(j), syndromes[i - j]));
@@ -732,14 +732,14 @@ public class ReedSolomon {
         System.out.print("roots: ");
         for (int i = 0; i < minDistance; i++) {
             System.out.print(Byte.toUnsignedInt(generatorRoots[i]));
-            if (i < (minDistance - 1)) {
+            if (i < minDistance - 1) {
                 System.out.print(", ");
             }
         }
         System.out.println('\n');
 
         System.out.print("generator: ");
-        for (int i = 0; i < (generator.getOrder() + 1); i++) {
+        for (int i = 0; i < generator.getOrder() + 1; i++) {
             System.out.print(Byte.toUnsignedInt(generator.getCoeff(i)) + "*x^" + i);
             if (i < generator.getOrder()) {
                 System.out.print(" + ");
@@ -759,7 +759,7 @@ public class ReedSolomon {
 
         System.out.print("remainder: ");
         boolean hasPrinted = false;
-        for (int i = 0; i < (encodedRemainder.getOrder() + 1); i++) {
+        for (int i = 0; i < encodedRemainder.getOrder() + 1; i++) {
             if (encodedRemainder.getCoeff(i) == 0) {
                 continue;
             }
@@ -774,7 +774,7 @@ public class ReedSolomon {
         System.out.print("syndromes: ");
         for (int i = 0; i < minDistance; i++) {
             System.out.print(Byte.toUnsignedInt(syndromes[i]));
-            if (i < (minDistance - 1)) {
+            if (i < minDistance - 1) {
                 System.out.print(", ");
             }
         }
@@ -784,7 +784,7 @@ public class ReedSolomon {
 
         System.out.print("error locator: ");
         hasPrinted = false;
-        for (int i = 0; i < (errorLocator.getOrder() + 1); i++) {
+        for (int i = 0; i < errorLocator.getOrder() + 1; i++) {
             if (errorLocator.getCoeff(i) == 0) {
                 continue;
             }
@@ -799,7 +799,7 @@ public class ReedSolomon {
         System.out.print("error roots: ");
         for (int i = 0; i < errorLocator.getOrder(); i++) {
             System.out.print(eval(field, errorLocator, errorRoots[i]) + "@" + Byte.toUnsignedInt(errorRoots[i]));
-            if (i < (errorLocator.getOrder() - 1)) {
+            if (i < errorLocator.getOrder() - 1) {
                 System.out.print(", ");
             }
         }
@@ -834,7 +834,7 @@ public class ReedSolomon {
         System.out.print("error locator: ");
         for(int i = 0; i < errorLocator.getOrder(); i++) {
             System.out.print(Byte.toUnsignedInt(errorVals[i]) + "@" + Byte.toUnsignedInt(errorLocations[i]));
-            if(i < (errorLocator.getOrder() - 1)) {
+            if(i < errorLocator.getOrder() - 1) {
                 System.out.print(", ");
             }
         }

--- a/src/main/java/libcorrect/reed_solomon/ReedSolomon.java
+++ b/src/main/java/libcorrect/reed_solomon/ReedSolomon.java
@@ -724,7 +724,7 @@ public class ReedSolomon {
      * Debug print
      */
     public void debugPrint() {
-        for (int i = 0; Integer.compareUnsigned(i, 256) < 0; i++) {
+        for (int i = 0; i < 256; i++) {
             System.out.printf("%3d  %3d    %3d  %3d\n", i, Byte.toUnsignedInt(field.exp(i)), i, Byte.toUnsignedInt(field.log(i)));
         }
         System.out.println();
@@ -798,7 +798,7 @@ public class ReedSolomon {
 
         System.out.print("error roots: ");
         for (int i = 0; i < errorLocator.getOrder(); i++) {
-            System.out.print(eval(field, errorLocator, errorRoots[i]) + "@" + Byte.toUnsignedInt(errorRoots[i]));
+            System.out.print(Byte.toUnsignedInt(eval(field, errorLocator, errorRoots[i])) + "@" + Byte.toUnsignedInt(errorRoots[i]));
             if (i < errorLocator.getOrder() - 1) {
                 System.out.print(", ");
             }

--- a/src/main/java/libcorrect/reed_solomon/ReedSolomon.java
+++ b/src/main/java/libcorrect/reed_solomon/ReedSolomon.java
@@ -741,7 +741,7 @@ public class ReedSolomon {
         System.out.print("generator: ");
         for (int i = 0; i < (generator.getOrder() + 1); i++) {
             System.out.print(Byte.toUnsignedInt(generator.getCoeff(i)) + "*x^" + i);
-            if (i < generator.getOrder()) < 0) {
+            if (i < generator.getOrder()) {
                 System.out.print(" + ");
             }
         }

--- a/src/main/java/libcorrect/reed_solomon/ReedSolomon.java
+++ b/src/main/java/libcorrect/reed_solomon/ReedSolomon.java
@@ -109,7 +109,7 @@ public class ReedSolomon {
         long msgLength = msg.length;
         byte[] encoded = new byte[(int) (msgLength+minDistance)];
 
-        if (Long.compareUnsigned(msgLength, maxMessageLength) > 0) {
+        if (msgLength > maxMessageLength) {
             throw new IllegalArgumentException("ReedSolomon.encode: message length must be smaller than block length - min. distance");
         }
 
@@ -130,11 +130,11 @@ public class ReedSolomon {
         Polynomial.mod(field, encodedPolynomial, generator, encodedRemainder);
 
         // now return byte order to highest order to lowest order
-        for (int i = 0; Long.compareUnsigned(Integer.toUnsignedLong(i), msgLength) < 0; i++) {
+        for (int i = 0; i < msgLength; i++) {
             encoded[i] = encodedPolynomial.getCoeff((int) (Integer.toUnsignedLong(encodedPolynomial.getOrder()) - (Integer.toUnsignedLong(i) + padLength)));
         }
 
-        for (int i = 0; Long.compareUnsigned(Integer.toUnsignedLong(i), minDistance) < 0; i++) {
+        for (int i = 0; i < minDistance; i++) {
             encoded[(int) (msgLength + Integer.toUnsignedLong(i))] = encodedRemainder.getCoeff((int) (minDistance - Integer.toUnsignedLong(i + 1)));
         }
 
@@ -156,7 +156,7 @@ public class ReedSolomon {
 
         long encodedLength = encoded.length;
 
-        if (Long.compareUnsigned(encodedLength, blockLength) > 0) {
+        if (encodedLength > blockLength) {
             throw new IllegalArgumentException("ReedSolomon.decode: encoded message length must be smaller than block length");
         }
 
@@ -178,12 +178,12 @@ public class ReedSolomon {
         // the final copied buffer will look like
         // | rem (rs->min_distance) | msg (msg_length) | pad (pad_length) |
 
-        for (int i = 0; Long.compareUnsigned(Integer.toUnsignedLong(i), encodedLength) < 0; i++) {
+        for (int i = 0; i < encodedLength; i++) {
             receivedPolynomial.setCoeff(i, encoded[(int) (encodedLength - (i + 1))]);
         }
 
         // fill the pad_length with 0s
-        for (int i = 0; Long.compareUnsigned(Integer.toUnsignedLong(i), padLength) < 0; i++) {
+        for (int i = 0; i < padLength; i++) {
             receivedPolynomial.setCoeff((int) (Integer.toUnsignedLong(i) + encodedLength), (byte) 0);
         }
 
@@ -193,7 +193,7 @@ public class ReedSolomon {
         if (allZero) {
             // syndromes were all zero, so there was no error in the message
             // copy to msg and we are done
-            for (int i = 0; Long.compareUnsigned(Integer.toUnsignedLong(i), msgLength) < 0; i++) {
+            for (int i = 0; i < msgLength; i++) {
                 msg[i] = receivedPolynomial.getCoeff((int) (encodedLength - Integer.toUnsignedLong(i + 1)));
             }
             return msg;
@@ -202,7 +202,7 @@ public class ReedSolomon {
         // XXX fix this vvvv
         errorLocator.setOrder(order);
 
-        for (int i = 0; Integer.compareUnsigned(i, errorLocator.getOrder()) <= 0; i++) {
+        for (int i = 0; i <= errorLocator.getOrder(); i++) {
             // this is a little strange since the coeffs are logs, not elements
             // also, we'll be storing log(0) = 0 for any 0 coeffs in the error locator
             // that would seem bad but we'll just be using this in chien search, and we'll skip all 0 coeffs
@@ -220,12 +220,12 @@ public class ReedSolomon {
         findErrorLocations(errorLocator.getOrder());
         findErrorValues();
 
-        for (int i = 0; Integer.compareUnsigned(i, errorLocator.getOrder()) < 0; i++) {
+        for (int i = 0; i < errorLocator.getOrder(); i++) {
             receivedPolynomial.setCoeff(Byte.toUnsignedInt(errorLocations[i]),
                     field.fieldSub(receivedPolynomial.getCoeff(Byte.toUnsignedInt(errorLocations[i])), errorVals[i]));
         }
 
-        for (int i = 0; Long.compareUnsigned(Integer.toUnsignedLong(i), msgLength) < 0; i++) {
+        for (int i = 0; i < msgLength; i++) {
             msg[i] = receivedPolynomial.getCoeff((int) (encodedLength - Integer.toUnsignedLong(i + 1)));
         }
         return msg;
@@ -281,10 +281,10 @@ public class ReedSolomon {
         }
 
         long encodedLength = encoded.length;
-        if (Long.compareUnsigned(encodedLength, blockLength) > 0) {
+        if (encodedLength > blockLength) {
             throw new IllegalArgumentException("ReedSolomon.decodeWithErasures: encoded message length must be smaller than block length");
         }
-        if (Long.compareUnsigned(erasureLength, minDistance) > 0) {
+        if (erasureLength > minDistance) {
             throw new IllegalArgumentException("ReedSolomon.decodeWithErasures: erasures  length must be smaller than min distance");
         }
 
@@ -306,16 +306,16 @@ public class ReedSolomon {
         // the final copied buffer will look like
         // | rem (rs->min_distance) | msg (msg_length) | pad (pad_length) |
 
-        for (int i = 0; Long.compareUnsigned(Integer.toUnsignedLong(i), encodedLength) < 0; i++) {
+        for (int i = 0; i < encodedLength; i++) {
             receivedPolynomial.setCoeff(i, encoded[(int) (encodedLength - Integer.toUnsignedLong(i + 1))]);
         }
 
         // fill the pad_length with 0s
-        for (int i = 0; Integer.toUnsignedLong(i) < padLength; i++) {
-            receivedPolynomial.setCoeff((int) (Integer.toUnsignedLong(i) + encodedLength), (byte) 0);
+        for (int i = 0; i < padLength; i++) {
+            receivedPolynomial.setCoeff((int) (i + encodedLength), (byte) 0);
         }
 
-        for (int i = 0; Long.compareUnsigned(Integer.toUnsignedLong(i), erasureLength) < 0; i++) {
+        for (int i = 0; i < erasureLength; i++) {
             // remap the coordinates of the erasures
             errorLocations[i] = (byte) (blockLength - (Byte.toUnsignedLong(erasureLocations[i]) + padLength + 1));
         }
@@ -329,7 +329,7 @@ public class ReedSolomon {
         if (allZero) {
             // syndromes were all zero, so there was no error in the message
             // copy to msg and we are done
-            for (int i = 0; Long.compareUnsigned(Integer.toUnsignedLong(i), msgLength) < 0; i++) {
+            for (int i = 0; i < msgLength; i++) {
                 msg[i] = receivedPolynomial.getCoeff((int) (encodedLength - Integer.toUnsignedLong(i + 1)));
             }
             return msg;
@@ -339,7 +339,7 @@ public class ReedSolomon {
 
         byte[] syndromeCopy_U = Arrays.copyOf(syndromes, (int) minDistance);
 
-        for (int i = (int) erasureLength; Long.compareUnsigned(Integer.toUnsignedLong(i), minDistance) < 0; i++) {
+        for (int i = (int) erasureLength; i < minDistance; i++) {
             syndromes[(int) (Integer.toUnsignedLong(i) - erasureLength)] = modifiedSyndromes[i];
         }
 
@@ -347,7 +347,7 @@ public class ReedSolomon {
         // XXX fix this vvvv
         errorLocator.setOrder(order);
 
-        for (int i = 0; Integer.compareUnsigned(i, errorLocator.getOrder()) <= 0; i++) {
+        for (int i = 0; i <= errorLocator.getOrder(); i++) {
             // this is a little strange since the coeffs are logs, not elements
             // also, we'll be storing log(0) = 0 for any 0 coeffs in the error locator
             // that would seem bad but we'll just be using this in chien search, and we'll skip all 0 coeffs
@@ -373,13 +373,13 @@ public class ReedSolomon {
         syndromes = Arrays.copyOf(syndromeCopy_U, (int) minDistance);
         findErrorValues();
 
-        for (int i = 0; Integer.compareUnsigned(i, errorLocator.getOrder()) < 0; i++) {
+        for (int i = 0; i < errorLocator.getOrder(); i++) {
             receivedPolynomial.setCoeff(Byte.toUnsignedInt(errorLocations[i]),
                     field.fieldSub(receivedPolynomial.getCoeff(Byte.toUnsignedInt(errorLocations[i])), errorVals[i]));
         }
 
         errorLocator = placeholderPoly;
-        for (int i = 0; Long.compareUnsigned(Integer.toUnsignedLong(i), msgLength) < 0; i++) {
+        for (int i = 0; i < msgLength; i++) {
             msg[i] = receivedPolynomial.getCoeff((int) (encodedLength - Integer.toUnsignedLong(i + 1)));
         }
         return msg;
@@ -400,7 +400,7 @@ public class ReedSolomon {
     private boolean findSyndromes(Polynomial msgpoly) {
         boolean allZero = true;
         Arrays.fill(syndromes, 0, (int) minDistance, (byte) 0);
-        for (int i = 0; Long.compareUnsigned(Integer.toUnsignedLong(i), minDistance) < 0; i++) {
+        for (int i = 0; i < minDistance; i++) {
             // profiling reveals that this function takes about 50% of the cpu time of
             // decoding. so, in order to speed it up a little, we precompute and save
             // the successive powers of the roots of the generator, which are
@@ -434,9 +434,9 @@ public class ReedSolomon {
         byte lastDiscrepancy = 1;
         int delayLength = 1;
 
-        for (int i = errorLocator.getOrder(); Long.compareUnsigned(Integer.toUnsignedLong(i), minDistance - numErasures) < 0; i++) {
+        for (int i = errorLocator.getOrder(); i < (minDistance - numErasures); i++) {
             discrepancy = syndromes[i];
-            for (int j = 1; Integer.compareUnsigned(j, numerrors) <= 0; j++) {
+            for (int j = 1; j <= numerrors; j++) {
                 discrepancy = (byte) field.fieldAdd(discrepancy, field.fieldMul(errorLocator.getCoeff(j), syndromes[i - j]));
             }
 
@@ -448,7 +448,7 @@ public class ReedSolomon {
                 continue;
             }
 
-            if (Integer.compareUnsigned(2 * numerrors, i) <= 0) {
+            if (2 * numerrors <= i) {
                 // there's a discrepancy, but we still have room for more taps
                 // lengthen LFSR by one tap and set weight to eliminate discrepancy
 
@@ -467,7 +467,7 @@ public class ReedSolomon {
                 // locator = locator - last_locator
                 // we will also update last_locator to be locator before this loop takes place
                 byte temp;
-                for (int j = 0; Integer.compareUnsigned(j, lastErrorLocator.getOrder() + delayLength) <= 0; j++) {
+                for (int j = 0; j <= (lastErrorLocator.getOrder() + delayLength); j++) {
                     temp = errorLocator.getCoeff(j);
                     errorLocator.setCoeff(j, field.fieldAdd(errorLocator.getCoeff(j), lastErrorLocator.getCoeff(j)));
                     lastErrorLocator.setCoeff(j, temp);
@@ -494,7 +494,7 @@ public class ReedSolomon {
                 errorLocator.setCoeff(j + delayLength, (byte) field.fieldAdd(errorLocator.getCoeff(j + delayLength),
                         field.fieldDiv(field.fieldMul(lastErrorLocator.getCoeff(j), discrepancy), lastDiscrepancy)));
             }
-            errorLocator.setOrder(Integer.compareUnsigned(lastErrorLocator.getOrder() + delayLength, errorLocator.getOrder()) > 0 ?
+            errorLocator.setOrder((lastErrorLocator.getOrder() + delayLength) > errorLocator.getOrder() ?
                     lastErrorLocator.getOrder() + delayLength : errorLocator.getOrder());
             delayLength++;
         }
@@ -579,7 +579,7 @@ public class ReedSolomon {
         formalDerivative(field, errorLocator, errorLocatorDerivative);
 
         // calculate each e(j)
-        for (int i = 0; Integer.compareUnsigned(i, errorLocator.getOrder()) < 0; i++) {
+        for (int i = 0; i < errorLocator.getOrder(); i++) {
             if (Byte.toUnsignedInt(errorRoots[i]) == 0) {
                 continue;
             }
@@ -609,7 +609,7 @@ public class ReedSolomon {
             }
 
             byte loc_U = field.fieldDiv((byte) 1, errorRoots[i]);
-            for (int j = 0; j < 256; j++) {
+            for (int j = 0; Integer.compareUnsigned(j, 256) < 0; j++) {
                 if (field.fieldPow((byte) j, gRootGap) == loc_U) {
                     errorLocations[i] = field.log(j);
                     break;
@@ -625,7 +625,7 @@ public class ReedSolomon {
      * @param numErrors
      */
     private void findErrorRootsFromLocations(byte generatorRootGap, int numErrors) {
-        for (int i = 0; Integer.compareUnsigned(i, numErrors) < 0; i++) {
+        for (int i = 0; i < numErrors; i++) {
             byte loc_U = field.fieldPow(field.exp(Byte.toUnsignedInt(errorLocations[i])), generatorRootGap);
             // field_element_t loc = field.exp[error_locations[i]];
             errorRoots[i] = field.fieldDiv((byte) 1, loc_U);
@@ -683,7 +683,7 @@ public class ReedSolomon {
         // if we save it, we can prevent the need to recalculate it on subsequent calls
         // total memory usage is min_distance * block_length bytes e.g. 32 * 255 ~= 8k
         generatorRootExp = new byte[(int) minDistance][];
-        for (int i = 0; Long.compareUnsigned(Integer.toUnsignedLong(i), minDistance) < 0; i++) {
+        for (int i = 0; i < minDistance; i++) {
             generatorRootExp[i] = new byte[(int) blockLength];
             buildExpLut(field, generatorRoots[i], (int) (blockLength - 1), generatorRootExp[i]);
         }
@@ -712,7 +712,7 @@ public class ReedSolomon {
      * @return
      */
     private Polynomial reedSolomonBuildGenerator(int nroots,  byte[] roots) {
-        for (int i = 0; Integer.compareUnsigned(i, nroots) < 0; i++) {
+        for (int i = 0; i < nroots; i++) {
             roots[i] = field.exp(Integer.remainderUnsigned(
                     gRootGap * (i + Byte.toUnsignedInt(fConsecutiveRoot)), 255));
         }
@@ -730,28 +730,28 @@ public class ReedSolomon {
         System.out.println();
 
         System.out.print("roots: ");
-        for (int i = 0; Long.compareUnsigned(Integer.toUnsignedLong(i), minDistance) < 0; i++) {
+        for (int i = 0; i < minDistance; i++) {
             System.out.print(Byte.toUnsignedInt(generatorRoots[i]));
-            if (Long.compareUnsigned(Integer.toUnsignedLong(i), minDistance - 1) < 0) {
+            if (i < (minDistance - 1)) {
                 System.out.print(", ");
             }
         }
         System.out.println('\n');
 
         System.out.print("generator: ");
-        for (int i = 0; Integer.compareUnsigned(i, generator.getOrder() + 1) < 0; i++) {
+        for (int i = 0; i < (generator.getOrder() + 1); i++) {
             System.out.print(Byte.toUnsignedInt(generator.getCoeff(i)) + "*x^" + i);
-            if (Integer.compareUnsigned(i, generator.getOrder()) < 0) {
+            if (i < generator.getOrder()) < 0) {
                 System.out.print(" + ");
             }
         }
         System.out.println('\n');
 
         System.out.print("generator (alpha format): ");
-        for (int i = generator.getOrder() + 1; Integer.compareUnsigned(i, 0) > 0; i--) {
+        for (int i = generator.getOrder() + 1; i > 0; i--) {
             System.out.print("alpha^" + Byte.toUnsignedInt(
                     field.log(Byte.toUnsignedInt(generator.getCoeff(i - 1)))) + "*x^" + (i - 1));
-            if (Integer.compareUnsigned(i, 1) > 0) {
+            if (i > 1) {
                 System.out.print(" + ");
             }
         }
@@ -759,7 +759,7 @@ public class ReedSolomon {
 
         System.out.print("remainder: ");
         boolean hasPrinted = false;
-        for (int i = 0; Integer.compareUnsigned(i, encodedRemainder.getOrder() + 1) < 0; i++) {
+        for (int i = 0; i < (encodedRemainder.getOrder() + 1); i++) {
             if (encodedRemainder.getCoeff(i) == 0) {
                 continue;
             }
@@ -772,9 +772,9 @@ public class ReedSolomon {
         System.out.println("\n");
 
         System.out.print("syndromes: ");
-        for (int i = 0; Long.compareUnsigned(Integer.toUnsignedLong(i), minDistance) < 0; i++) {
+        for (int i = 0; i < minDistance; i++) {
             System.out.print(Byte.toUnsignedInt(syndromes[i]));
-            if (Long.compareUnsigned(Integer.toUnsignedLong(i), minDistance - 1) < 0) {
+            if (i < (minDistance - 1)) {
                 System.out.print(", ");
             }
         }
@@ -784,7 +784,7 @@ public class ReedSolomon {
 
         System.out.print("error locator: ");
         hasPrinted = false;
-        for (int i = 0; Integer.compareUnsigned(i, errorLocator.getOrder() + 1) < 0; i++) {
+        for (int i = 0; i < (errorLocator.getOrder() + 1); i++) {
             if (errorLocator.getCoeff(i) == 0) {
                 continue;
             }
@@ -797,16 +797,16 @@ public class ReedSolomon {
         System.out.println("\n");
 
         System.out.print("error roots: ");
-        for (int i = 0; Integer.compareUnsigned(i, errorLocator.getOrder()) < 0; i++) {
+        for (int i = 0; i < errorLocator.getOrder(); i++) {
             System.out.print(eval(field, errorLocator, errorRoots[i]) + "@" + Byte.toUnsignedInt(errorRoots[i]));
-            if (Integer.compareUnsigned(i, errorLocator.getOrder() - 1) < 0) {
+            if (i < (errorLocator.getOrder() - 1)) {
                 System.out.print(", ");
             }
         }
         System.out.println("\n");
 
         hasPrinted = false;
-        for(int i = 0; Integer.compareUnsigned(i, errorEvaluator.getOrder()) < 0; i++) {
+        for(int i = 0; i < errorEvaluator.getOrder(); i++) {
             if(errorEvaluator.getCoeff(i) == 0) {
                 continue;
             }
@@ -819,7 +819,7 @@ public class ReedSolomon {
         System.out.println("\n");
 
         hasPrinted = false;
-        for(int i = 0; Integer.compareUnsigned(i, errorLocatorDerivative.getOrder()) < 0; i++) {
+        for(int i = 0; i < errorLocatorDerivative.getOrder(); i++) {
             if(errorLocatorDerivative.getCoeff(i) == 0) {
                 continue;
             }
@@ -832,9 +832,9 @@ public class ReedSolomon {
         System.out.println("\n");
 
         System.out.print("error locator: ");
-        for(int i = 0; Integer.compareUnsigned(i, errorLocator.getOrder()) < 0; i++) {
+        for(int i = 0; i < errorLocator.getOrder(); i++) {
             System.out.print(Byte.toUnsignedInt(errorVals[i]) + "@" + Byte.toUnsignedInt(errorLocations[i]));
-            if(Integer.compareUnsigned(i, errorLocator.getOrder() - 1) < 0) {
+            if(i < (errorLocator.getOrder() - 1)) {
                 System.out.print(", ");
             }
         }

--- a/src/main/java/libcorrect/reed_solomon/ReedSolomon.java
+++ b/src/main/java/libcorrect/reed_solomon/ReedSolomon.java
@@ -609,7 +609,7 @@ public class ReedSolomon {
             }
 
             byte loc_U = field.fieldDiv((byte) 1, errorRoots[i]);
-            for (int j = 0; Integer.compareUnsigned(j, 256) < 0; j++) {
+            for (int j = 0; j < 256; j++) {
                 if (field.fieldPow((byte) j, gRootGap) == loc_U) {
                     errorLocations[i] = field.log(j);
                     break;


### PR DESCRIPTION
There are a number of locations within the Reed Solomon implementation where there are unnecessary method calls to compareUnsigned methods. These are all calls on non-negative values, within the signed positive range, that are used as array indices.  For these cases, signed and unsigned comparison behave identically.  This pull request changes these from unsigned to signed comparison. This has two benefits: it reduces code clutter, and it somewhat improves performance by removing the overhead of the method call.